### PR TITLE
OpenCL device override and backend selection via Environment Variable and system property

### DIFF
--- a/src/java/clearvolume/renderer/factory/ClearVolumeRendererFactory.java
+++ b/src/java/clearvolume/renderer/factory/ClearVolumeRendererFactory.java
@@ -211,7 +211,7 @@ public class ClearVolumeRendererFactory
 		{
 			final Properties lProperties = new Properties(System.getProperties());
 
-			if (lProperties.getProperty("ClearVolume.disableOpenCL") == null)
+			if (lProperties.getProperty("ClearVolume.disableOpenCL") == null && System.getenv("CV_DISABLE_OPENCL") == null)
 			{
 				final ClearVolumeRendererInterface lNewOpenCLRenderer = internalCreateOpenCLRenderer(	pWindowName,
 																																														pWindowWidth,
@@ -228,7 +228,7 @@ public class ClearVolumeRendererFactory
 				System.err.println("Caution: Use of OpenCL has been explicitly disabled!");
 			}
 
-			if (lProperties.getProperty("ClearVolume.disableCUDA") == null)
+			if (lProperties.getProperty("ClearVolume.disableCUDA") == null && System.getenv("CV_DISABLE_CUDA") == null)
 			{
 				final ClearVolumeRendererInterface lNewCudaRenderer = internalCreateCudaRenderer(	pWindowName,
 																																													pWindowWidth,

--- a/src/java/clearvolume/renderer/opencl/OpenCLDevice.java
+++ b/src/java/clearvolume/renderer/opencl/OpenCLDevice.java
@@ -108,6 +108,7 @@ public class OpenCLDevice implements ClearVolumeCloseable
 			long lMaxMemory = 0;
 
 			CLPlatform lBestPlatform = null;
+
 			for (final CLPlatform lCLPlatform : lCLPlatforms)
 			{
 				final CLDevice lBestCLDeviceForPlateform = getDeviceWithMostMemory(	pGPUOnly,
@@ -127,6 +128,16 @@ public class OpenCLDevice implements ClearVolumeCloseable
 							e.printStackTrace();
 						}
 					}
+			}
+
+			final String lPreferredPlatform = System.getenv("CLEARVOLUME_DEVICE");
+			String[] lPreferred = lPreferredPlatform.split(",");
+
+			if(lPreferred.length == 2 && Integer.parseInt(lPreferred[0]) < lCLPlatforms.length &&
+							Integer.parseInt(lPreferred[1]) < lCLPlatforms[Integer.parseInt(lPreferred[0])].listAllDevices(true).length) {
+				System.out.println("Overriding device selection:");
+				lBestDevice = lCLPlatforms[Integer.parseInt(lPreferred[0])].listAllDevices(true)[Integer.parseInt(lPreferred[1])];
+				lBestPlatform = lCLPlatforms[Integer.parseInt(lPreferred[0])];
 			}
 
 			if (lBestPlatform != null && lBestDevice != null)

--- a/src/java/clearvolume/renderer/opencl/OpenCLDevice.java
+++ b/src/java/clearvolume/renderer/opencl/OpenCLDevice.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.ShortBuffer;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 
 import org.bridj.Pointer;
@@ -130,14 +131,21 @@ public class OpenCLDevice implements ClearVolumeCloseable
 					}
 			}
 
-			final String lPreferredPlatform = System.getenv("CLEARVOLUME_DEVICE");
-			String[] lPreferred = lPreferredPlatform.split(",");
+			try {
+				final String lPreferredPlatform = System.getenv("CV_OPENCL_DEVICE");
+				final String[] lPreferred = lPreferredPlatform.split(",");
 
-			if(lPreferred.length == 2 && Integer.parseInt(lPreferred[0]) < lCLPlatforms.length &&
-							Integer.parseInt(lPreferred[1]) < lCLPlatforms[Integer.parseInt(lPreferred[0])].listAllDevices(true).length) {
-				System.out.println("Overriding device selection:");
-				lBestDevice = lCLPlatforms[Integer.parseInt(lPreferred[0])].listAllDevices(true)[Integer.parseInt(lPreferred[1])];
-				lBestPlatform = lCLPlatforms[Integer.parseInt(lPreferred[0])];
+				final int platformId = Integer.parseInt(lPreferred[0]);
+				final int deviceId = Integer.parseInt(lPreferred[1]);
+
+				if(lPreferred.length == 2 && platformId < lCLPlatforms.length &&
+								deviceId < lCLPlatforms[platformId].listAllDevices(true).length) {
+					System.out.println("Overriding device selection:");
+					lBestDevice = lCLPlatforms[platformId].listAllDevices(true)[deviceId];
+					lBestPlatform = lCLPlatforms[platformId];
+				}
+			} catch(final NumberFormatException | ArrayIndexOutOfBoundsException e) {
+				System.err.println("Invalid specification for device and platform IDs. Please set as CV_OPENCL_DEVICE=platformId,deviceId");
 			}
 
 			if (lBestPlatform != null && lBestDevice != null)

--- a/src/java/clearvolume/renderer/opencl/OpenCLDevice.java
+++ b/src/java/clearvolume/renderer/opencl/OpenCLDevice.java
@@ -132,7 +132,12 @@ public class OpenCLDevice implements ClearVolumeCloseable
 			}
 
 			try {
-				final String lPreferredPlatform = System.getenv("CV_OPENCL_DEVICE");
+				String lPreferredPlatform = System.getenv("CV_OPENCL_DEVICE");
+
+				if(lPreferredPlatform == null) {
+					lPreferredPlatform = System.getProperty("ClearVolume.OpenCLDevice");
+				}
+
 				final String[] lPreferred = lPreferredPlatform.split(",");
 
 				final int platformId = Integer.parseInt(lPreferred[0]);


### PR DESCRIPTION
This PR enables overriding the OpenCL device selection by CV.

* CUDA or OpenCL may now be enforced by either setting the
  System Properties `ClearVolume.disableOpenCL` or `ClearVolume.disableCUDA`,
  or the env variables `CV_DISABLE_OPENCL` or `CV_DISABLE_CUDA`.
* the OpenCL device to be used can now be selected by defining
  the env var `CV_OPENCL_DEVICE=platformId,deviceId` to force ClearVolume
  to use the respective device without taking this device's fitness
  into account.