### PR TITLE
Rotate intuitively around a clipbox.

### DIFF
--- a/src/java/clearvolume/renderer/cleargl/ClearGLVolumeRenderer.java
+++ b/src/java/clearvolume/renderer/cleargl/ClearGLVolumeRenderer.java
@@ -705,11 +705,21 @@ public abstract class ClearGLVolumeRenderer extends
     final GLMatrix lModelViewMatrix = new GLMatrix();
     lModelViewMatrix.setIdentity();
 
-    lModelViewMatrix.translate(getTranslationX(),
-                               getTranslationY(),
-                               getTranslationZ());
+    //lModelViewMatrix.translate(getTranslationX(),
+    //                           getTranslationY(),
+    //                           getTranslationZ());
 
+    final float[] clipBox = getClipBox();
+    lModelViewMatrix.translate( (clipBox[0] + clipBox[1])/ 2.0f + getTranslationX(), 
+            (clipBox[2] + clipBox[3]) / 2.0f + getTranslationY(),
+            (clipBox[4] + clipBox[5]) / 2.0f + getTranslationZ() );
+    
     lModelViewMatrix.mult(getQuaternion());
+    
+    lModelViewMatrix.translate( - (clipBox[0] + clipBox[1])/ 2.0f, 
+            - (clipBox[2] + clipBox[3]) / 2.0f,
+            - (clipBox[4] + clipBox[5]) / 2.0f );
+    
 
     lModelViewMatrix.scale((float) (lScaleX / lMaxScale),
                            (float) (lScaleY / lMaxScale),

--- a/src/java/clearvolume/renderer/cleargl/ClearGLVolumeRenderer.java
+++ b/src/java/clearvolume/renderer/cleargl/ClearGLVolumeRenderer.java
@@ -705,25 +705,22 @@ public abstract class ClearGLVolumeRenderer extends
     final GLMatrix lModelViewMatrix = new GLMatrix();
     lModelViewMatrix.setIdentity();
 
-    //lModelViewMatrix.translate(getTranslationX(),
-    //                           getTranslationY(),
-    //                           getTranslationZ());
-
     final float[] clipBox = getClipBox();
-    lModelViewMatrix.translate( (clipBox[0] + clipBox[1])/ 2.0f + getTranslationX(), 
+    lModelViewMatrix.translate( 
+            (clipBox[0] + clipBox[1])/ 2.0f + getTranslationX(), 
             (clipBox[2] + clipBox[3]) / 2.0f + getTranslationY(),
             (clipBox[4] + clipBox[5]) / 2.0f + getTranslationZ() );
     
     lModelViewMatrix.mult(getQuaternion());
     
-    lModelViewMatrix.translate( - (clipBox[0] + clipBox[1])/ 2.0f, 
+    lModelViewMatrix.translate( 
+            - (clipBox[0] + clipBox[1])/ 2.0f, 
             - (clipBox[2] + clipBox[3]) / 2.0f,
             - (clipBox[4] + clipBox[5]) / 2.0f );
     
-
     lModelViewMatrix.scale((float) (lScaleX / lMaxScale),
                            (float) (lScaleY / lMaxScale),
-                           (float) (lScaleZ / lMaxScale));/**/
+                           (float) (lScaleZ / lMaxScale));
 
     return lModelViewMatrix;
   }


### PR DESCRIPTION
Changes the getModelViewMatrix function.  First translates to the
middles of the clipbox, rotates, then translates back.  End result is
a rotation around the center of the clipbox, which is much more intuitive
that rotating around the center of the complete volume. Tested in the 
Micro-Manager ClearVolume plugin and works quite well. There should be
no change if no clipbox is set.