### PR TITLE
Remove const modifier on float4 color definition in volume kernel

### DIFF
--- a/src/java/clearvolume/renderer/opencl/kernels/VolumeRender.cl
+++ b/src/java/clearvolume/renderer/opencl/kernels/VolumeRender.cl
@@ -292,7 +292,8 @@ maxproj_render(					 __global uint	*d_output,
 	
 
 	// lookup in transfer function texture:
-  const float4 color = brightness*read_imagef(transferColor4,transferSampler, (float2)(mappedVal,0.0f));
+	// AW: I deleted the const modifier here; this allows ClearVolume to work on Intel openCL driver
+ float4 color = brightness*read_imagef(transferColor4,transferSampler, (float2)(mappedVal,0.0f));
   
   // Alpha pre-multiply:
   color.x = color.x*color.w;


### PR DESCRIPTION
There is a bug with the ClearVolume Fiji plugin where it is unable to compile the VolumeRender kernel on Intel GPUs. The plugin works fine on Nvidia GPUs, but on a PC with an Intel GPU the window appears blank, and an error message appears in the log (as well as a full output of the source code). An example of this error code can be found in #76; there are a lot of other examples of errors with NullPointerExceptions, and I wonder if they are related! 

Basically, there is a float4 definition for "color" that is labeled const, but then immediately modified right after that. For whatever reason, Nvidia GPUs seem to be fine with this, but Intel must be stricter and fails to compile. Removing the "const" allows the kernel to compile on both Nvidia and Intel, but I haven't tested it anywhere else yet. 

I think, given the code that is right below the color variable definition, it is NOT meant to be const, but I am absolutely not familiar with OpenCL development _at all_, nor could I even safely call myself a Java developer. If this change is dangerous, I hope someone else might catch it; however, I can say that I am very happy to finally be able to use CV on my intel-GPU laptop!