### PR TITLE
Uses scijava pom version 44.0.0

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-gradle assemble --stacktrace
-test "$MAVEN_USER" -a "$MAVEN_PASS" -a \
-  -z "$BUILD_BASE_REF" -a -z "$BUILD_HEAD_REF" &&
-  gradle publish

--- a/.github/setup.sh
+++ b/.github/setup.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/main/ci-setup-github-actions.sh
-sh ci-setup-github-actions.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,33 +3,28 @@ name: build
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*-[0-9]+.*"
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
-          cache: 'gradle'
-      - name: Set up CI environment
-        run: .github/setup.sh
-      - name: Execute the build
-        run: .github/build.sh
-        env:
-          GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASS: ${{ secrets.MAVEN_PASS }}
-          OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
-          SIGNING_ASC: ${{ secrets.SIGNING_ASC }}
+          cache: 'maven'
+      - name: Build and run headless tests
+        # The compiler targets Java 8 bytecode (maven.compiler.release=8 in
+        # pom.xml) so the artifact loads in Fiji's runtime. The Surefire
+        # config in pom.xml excludes tests that open OpenGL/OpenCL/NEWT
+        # windows or wait on the network, so only headless tests run here.
+        run: mvn -B --no-transfer-progress -Djava.awt.headless=true verify

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>40.0.0</version>
+		<version>44.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -133,6 +133,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>net.coremem</groupId>
+			<artifactId>coremem</artifactId>
+			<version>${coremem.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>net.clearvolume</groupId>
 			<artifactId>clearcl</artifactId>
 			<version>${clearcl.version}</version>
@@ -162,12 +167,12 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<sourceDirectory>${project.basedir}/src/java</sourceDirectory>
-		<testSourceDirectory>${project.basedir}/src/java</testSourceDirectory>
+    <build>
+    <sourceDirectory>${project.basedir}/src/java</sourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/java</testSourceDirectory>
     <resources>
       <resource>
-				<directory>${project.basedir}/src/java</directory>
+        <directory>${project.basedir}/src/java</directory>
         <excludes>
           <exclude>**/*.java</exclude>
           <exclude>**/package.html</exclude>
@@ -176,7 +181,7 @@
     </resources>
     <testResources>
       <testResource>
-				<directory>${project.basedir}/src/java</directory>
+	<directory>${project.basedir}/src/java</directory>
         <excludes>
           <exclude>**/*.java</exclude>
           <exclude>**/package.html</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,20 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
+		<!--
+			Target Java 8 (class file version 52) so the artifact loads in
+			Fiji installs running a Java 8 runtime. pom-scijava 44 defaults to
+			Java 11 (class file version 55). Both cleargl and JOGL 2.6.0 are
+			compiled for Java 8, so this is safe.
+		-->
+		<scijava.jvm.version>8</scijava.jvm.version>
+		<maven.compiler.release>8</maven.compiler.release>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
+
 		<clearcl.version>0.5.2</clearcl.version>
 		<clearaudio.version>1.0.2</clearaudio.version>
-		<cleargl.version>2.2.11</cleargl.version>
+		<cleargl.version>2.2.12-SNAPSHOT</cleargl.version>
 		<orange-extensions.version>1.3.0</orange-extensions.version>
 	</properties>
 
@@ -188,6 +199,30 @@
         </excludes>
       </testResource>
     </testResources>
+
+    <plugins>
+      <!--
+        Exclude tests that open OpenGL/OpenCL/NEWT windows or wait on the
+        network. These create real renderers (setVisible) whose non-daemon
+        NEWT threads keep the forked JVM alive, causing "mvn test" to hang
+        and never return. They remain runnable manually, e.g.:
+          mvn test -Dtest=OpenCLVolumeRendererTests
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/CheckRequirementsTests.java</exclude>
+            <exclude>**/ClearVolumeCTests.java</exclude>
+            <exclude>**/ClearVolumeNetworkTests.java</exclude>
+            <exclude>**/ClearVolumeRendererFactoryTests.java</exclude>
+            <exclude>**/OpenCLTests.java</exclude>
+            <exclude>**/OpenCLVolumeRendererTests.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
 
 	</build>
 </project>

--- a/src/java/clearvolume/controller/AutoRotationController.java
+++ b/src/java/clearvolume/controller/AutoRotationController.java
@@ -1,6 +1,6 @@
 package clearvolume.controller;
 
-import com.jogamp.opengl.math.Quaternion;
+import com.jogamp.math.Quaternion;
 
 import clearvolume.renderer.ClearVolumeRendererInterface;
 

--- a/src/java/clearvolume/controller/QuaternionRotationControllerBase.java
+++ b/src/java/clearvolume/controller/QuaternionRotationControllerBase.java
@@ -1,6 +1,6 @@
 package clearvolume.controller;
 
-import com.jogamp.opengl.math.Quaternion;
+import com.jogamp.math.Quaternion;
 
 /**
  * Class QuaternionRotationControllerBase

--- a/src/java/clearvolume/controller/RotationControllerInterface.java
+++ b/src/java/clearvolume/controller/RotationControllerInterface.java
@@ -1,6 +1,6 @@
 package clearvolume.controller;
 
-import com.jogamp.opengl.math.Quaternion;
+import com.jogamp.math.Quaternion;
 
 /**
  * Class RotationControllerInterface

--- a/src/java/clearvolume/renderer/ClearVolumeRendererBase.java
+++ b/src/java/clearvolume/renderer/ClearVolumeRendererBase.java
@@ -15,7 +15,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import javax.swing.SwingUtilities;
 
-import com.jogamp.opengl.math.Quaternion;
+import com.jogamp.math.Quaternion;
 
 import clearvolume.ClearVolumeCloseable;
 import clearvolume.controller.AutoRotationController;

--- a/src/java/clearvolume/renderer/ClearVolumeRendererInterface.java
+++ b/src/java/clearvolume/renderer/ClearVolumeRendererInterface.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 import com.jogamp.newt.awt.NewtCanvasAWT;
-import com.jogamp.opengl.math.Quaternion;
+import com.jogamp.math.Quaternion;
 
 import clearvolume.ClearVolumeCloseable;
 import clearvolume.controller.AutoRotationController;

--- a/src/java/clearvolume/renderer/cleargl/ClearGLVolumeRenderer.java
+++ b/src/java/clearvolume/renderer/cleargl/ClearGLVolumeRenderer.java
@@ -23,7 +23,7 @@ import com.jogamp.opengl.GL;
 import com.jogamp.opengl.GL2ES3;
 import com.jogamp.opengl.GLAutoDrawable;
 import com.jogamp.opengl.GLProfile;
-import com.jogamp.opengl.math.Quaternion;
+import com.jogamp.math.Quaternion;
 
 import cleargl.ClearGLEventListener;
 import cleargl.ClearGLWindow;


### PR DESCRIPTION
This results in using jogl2.6.0, cleargl 2.2.12 (which still needs to be released, update SNAPSHOT in the current pom for cleargl once it is available).

Also changes github actions to use a mvn build (and test) rather than gradle.